### PR TITLE
_maxCOF+16 on fam.12h according to k10stat

### DIFF
--- a/FusionTweaker/PStateControl.cs
+++ b/FusionTweaker/PStateControl.cs
@@ -81,7 +81,7 @@ namespace FusionTweaker
                     //Brazos merge next line added from BT
                     _maxPstate = K10Manager.GetHighestPState();
                     _family = K10Manager.GetFamily();
-                    if (_family == 14)
+                    if (_family == 14 || _family == 12)
                     {
                         _maxCOF = K10Manager.MaxCOF() + 16;
                     }


### PR DESCRIPTION
fixes exception on startup
![capture_001_06122016_172012](https://cloud.githubusercontent.com/assets/24415704/20934951/3fea0766-bbdd-11e6-93b5-09ae067e041d.png)

the min and max values were 4 respectively 24
k10stat says:
![maxcof](https://cloud.githubusercontent.com/assets/24415704/20935049/99893a9e-bbdd-11e6-86dd-fe90027174d6.png)
so, it should be 24+16.



Unrelated side note: If I want to edit this project in the future, this is what I need:


* Needed: visual studio 2010 ultimate trial  (not Visual Studio 2010 Express which misses needed features to open project)  + Service Pack 1 (maybe optional?)
See here for direct download links: https://stackoverflow.com/questions/8894654/where-can-i-download-visual-studio-2010-trial-version/8894857#8894857


Get rid of some .NET Framework 3.5 warnings (possibly optional?):

* do this https://stackoverflow.com/questions/221913/net-3-5-sp1-bootstrapper-not-found-for-setup/5556080#5556080


* in vs2010, in Solution Explorer, click on 'FusionTweaker x64 Setup' and right click, select Properties. Click Prerequisites button.
Deselect '.Net Framework 3.5' and select '.Net Framework 3.5 SP1'. Select Ok, Ok.
Build->Clean Solution
Build->Rebuild Soltion.

The warnings about .NET Framework 3.5 should be gone.
